### PR TITLE
Ensure bad responses from the Fastly API fail the deploy

### DIFF
--- a/lib/fastly/lib/index.js
+++ b/lib/fastly/lib/index.js
@@ -96,9 +96,8 @@ Fastly.prototype.request = function (method, url, params) {
 		}
 
 		if (err) return deferred.reject(body);
-		if (response.statusCode < 200) return deferred.resolve(body);
-		if (response.statusCode > 400) return deferred.reject(body);
 		if (response.statusCode > 302) return deferred.resolve(body);
+		if (response.statusCode >= 400) return deferred.reject(body);
 
 		if (response.headers['content-type'] === 'application/json') {
 			try {


### PR DESCRIPTION
The Fastly API returns a `400 Bad Request` response when you are attempting to create a new backend and are over your soft-limit of backends per service. 

The underlying Fastly API library that we use within this project assumed that only status codes _above_ `400` were errors, thus resolving the promise for the an errored create backend request as detailed above. This was then causing the deploy task to continue running and upload the vcl referencing said new backends which in-turn would cause a VCL compilation error when uploaded.

We wasted nearly 4 days due to this simple error. 😬 