### PR TITLE
Add Snyk to components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/fastly-tools
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "make test",
     "precommit": "node_modules/.bin/secret-squirrel",
     "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make verify -j3"
+    "prepush": "make verify -j3",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "engines": {
     "node": ">=5.10.1"
@@ -35,6 +36,7 @@
     "npm-prepublish": "^1.2.1",
     "proxyquire": "^1.7.4",
     "sinon": "^1.17.3",
+    "snyk": "^1.167.2",
     "tap": "^5.7.1"
   },
   "dependencies": {


### PR DESCRIPTION
We are installing [Snyk](https://snyk.io) in all of our repos for security reasons. It will patch or ignore known vulnerabilities. Currently Snyk is enabled on our repos (config and results can be viewed from the Snyk webpage) but we want to install it on each project for increased security when building. See https://github.com/Financial-Times/next/issues/365