### PR TITLE
NOPS-48 remove references to FastFT

### DIFF
--- a/test/fixtures/backends.json
+++ b/test/fixtures/backends.json
@@ -53,16 +53,6 @@
       "healthcheck": "access_healthcheck"
     },
     {
-      "name": "fastft",
-      "connect_timeout": 3000,
-      "port": "80",
-      "hostname": "fastft.glb.ft.com",
-      "first_byte_timeout": 1000,
-      "max_conn": 200,
-      "between_bytes_timeout": 1000,
-      "healthcheck": "fastft_healthcheck"
-    },
-    {
       "name": "access_test",
       "connect_timeout": 3000,
       "port": "80",


### PR DESCRIPTION
Removed reference to FastFT as part of [NOPS-48](https://financialtimes.atlassian.net/browse/NOPS-48)

[NOPS-48]: https://financialtimes.atlassian.net/browse/NOPS-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ