### PR TITLE
NOPS-48 Remove FastFT healthcheck from backends

### DIFF
--- a/test/fixtures/backends.json
+++ b/test/fixtures/backends.json
@@ -53,16 +53,6 @@
       "healthcheck": "access_healthcheck"
     },
     {
-      "name": "fastft",
-      "connect_timeout": 3000,
-      "port": "80",
-      "hostname": "fastft.glb.ft.com",
-      "first_byte_timeout": 1000,
-      "max_conn": 200,
-      "between_bytes_timeout": 1000,
-      "healthcheck": "fastft_healthcheck"
-    },
-    {
       "name": "access_test",
       "connect_timeout": 3000,
       "port": "80",


### PR DESCRIPTION
## description
FastFT has been removed from frontpage and it's no longer a feature being used.
This PR is to remove the FastFT healthcheck endpoint from the list of backends.

## meta
[NOPS-48](https://financialtimes.atlassian.net/browse/NOPS-48)