### PR TITLE
Fix issues with engines enforcement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       },
       "engines": {
         "node": "12.x",
-        "npm": "7.x"
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "engines": {
     "node": "12.x",
-    "npm": "7.x"
+    "npm": "7.x || 8.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two changes to enforcing the right version of node and npm with `check-engines`:

1. Improve compatibility of check-engines guard: some shells in use (particularly in our CI and build images) do not support the non-POSIX `[[` command, so use the more portable `[` built-in instead.
2. Allow npm 8: the only breaking change in npm8 is dropping support for `node<12`, but we already require `node@12` so this doesn't affect us and will allow for newer npm versions to be used.