### PR TITLE
cpp-683 update dotenv and add as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Commands:
 ```sh
 Usage: deploy [options] [folder]
 
-Deploys VCL in [folder] to the specified fastly service. Requires FASTLY_APIKEY env var which can be found in the repo's corresponding Vault directory.
+Deploys VCL in [folder] to the specified fastly service. Requires FASTLY_APIKEY env var which can be found in the repo\'s corresponding Vault directory.
 
 Options:
   -m, --main <main>               Set the name of the main vcl file (the entry point).  Defaults to "main.vcl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "colors": "^1.1.2",
         "commander": "^2.9.0",
         "debug": "^2.2.0",
+        "dotenv": "^10.0.0",
         "node-fetch": "^1.5.0",
         "request": "^2.72.0"
       },
@@ -6123,6 +6124,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dotnet-deps-parser": {
@@ -22927,6 +22936,11 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "dotnet-deps-parser": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "colors": "^1.1.2",
     "commander": "^2.9.0",
     "debug": "^2.2.0",
+    "dotenv": "^10.0.0",
     "node-fetch": "^1.5.0",
     "request": "^2.72.0"
   },

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -20,7 +20,7 @@ function task (folder, opts) {
 	}, opts);
 
 	if (options.env) {
-		require('dotenv').load();
+		require('dotenv').config();
 	}
 
 	const log = require('../lib/logger')({verbose:options.verbose, disabled:options.disableLogs});


### PR DESCRIPTION
dotenv was not in `package.json` and therefore was downloading the latest version (10x), however it makes use of the `load` alias, that was [deprecated in version 7](https://github.com/motdotla/dotenv/compare/v6.2.0...v7.0.0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80). As this is just an alias for `config`, I think it makes sense to do the following in this PR:

- upgrade to the latest version
- add in `package.json` 
- replace `load()` with `config()`
