### PR TITLE
CPP-890 update config for nightly scheduled-pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,11 @@ workflows:
   version: 2
 
   build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -146,6 +151,11 @@ workflows:
             - build
 
   build-test-publish:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -163,6 +173,11 @@ workflows:
             - test
 
   renovate-nori-build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - waiting-for-approval:
           type: approval
@@ -176,11 +191,14 @@ workflows:
             - build
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            <<: *filters_only_main
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
     jobs:
       - build:
           context: next-nightly-build


### PR DESCRIPTION
Applies workflows filtering to your circleci/config.yml, so that the nightly workflow runs with the scheduled trigger, and other workflows won't run with the scheduled trigger.