### PR TITLE
Update to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ references:
     &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:16.14
+      - image: cimg/node:18.16
 
   workspace_root: &workspace_root ~/project
 
@@ -79,11 +79,9 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch unpin-heroku
             .circleci/shared-helpers
       - *restore_npm_cache
-      - node/install-npm:
-          version: "7"
       - run:
           name: Install project dependencies
           command: make install

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/fastly-tools",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "array.prototype.includes": "^1.0.0",
@@ -37,8 +36,8 @@
         "tap": "^5.7.1"
       },
       "engines": {
-        "node": "12.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,11 @@
   },
   "scripts": {
     "test": "make test",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "engines": {
-    "node": "16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "repository": {
     "type": "git",
@@ -57,7 +56,6 @@
     }
   },
   "volta": {
-    "node": "16.14.2",
-    "npm": "7.20.2"
+    "node": "18.16.0"
   }
 }


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)